### PR TITLE
CCM_SoftwareUpdate classes

### DIFF
--- a/sccmclictr.automation/SoftwareUpdates.cs
+++ b/sccmclictr.automation/SoftwareUpdates.cs
@@ -1370,7 +1370,7 @@ namespace sccmclictr.automation.functions
         /// <summary>
         /// Source:ROOT\ccm\ClientSDK
         /// </summary>
-        public class CCM_SoftwareUpdate : softwaredistribution.CCM_SoftwareBase
+        public class CCM_SoftwareUpdate : softwaredistribution.CCM_SoftwareUpdate
         {
             internal baseInit oNewBase;
 
@@ -1382,7 +1382,7 @@ namespace sccmclictr.automation.functions
             /// <param name="RemoteRunspace">The remote runspace.</param>
             /// <param name="PSCode">The PowerShell code.</param>
             public CCM_SoftwareUpdate(PSObject WMIObject, Runspace RemoteRunspace, TraceSource PSCode)
-                : base(WMIObject)
+                : base(WMIObject, RemoteRunspace, PSCode)
             {
                 remoteRunspace = RemoteRunspace;
                 pSCode = PSCode;


### PR DESCRIPTION
Inherit from SoftwareDistribution's implementation of CCM_SoftwareUpdate, rather than directly from SoftwareDistribution.CCM_SoftwareBase so that it has stuff like EvaluationStateText which is only in one.

I'm not sure why/how they're different, possibly a better solution would be to remove one of the versions. There's negligible use of the SoftwareDistribution version in this, and none at all in SCCMCliCtr.