### PR TITLE
Look up error codes on software to provide error messages

### DIFF
--- a/sccmclictr.automation/SoftwareDistribution.cs
+++ b/sccmclictr.automation/SoftwareDistribution.cs
@@ -438,6 +438,7 @@ namespace sccmclictr.automation.functions
             public DateTime? Deadline { get; set; }
             public String Description { get; set; }
             public UInt32? ErrorCode { get; set; }
+            public String ErrorCodeText { get; set; }
             public UInt32? EstimatedInstallTime { get; set; }
             public UInt32? EvaluationState { get; set; }
             public String FullName { get; set; }
@@ -479,6 +480,16 @@ namespace sccmclictr.automation.functions
 
                 this.Description = WMIObject.Properties["Description"].Value as string;
                 this.ErrorCode = WMIObject.Properties["ErrorCode"].Value as uint?;
+                try
+                {
+                    Assembly SrsResources = Assembly.LoadFile(@"C:\\Program Files (x86)\\Microsoft Configuration Manager\\AdminConsole\bin\\SrsResources.dll");
+                    Type Localization = SrsResources.GetType("SrsResources.Localization");
+                    ErrorCodeText = Localization.GetMethod("GetErrorMessage").Invoke(null, new object[] { ErrorCode.ToString(), "en-US" }).ToString();
+                }
+                catch (Exception e)
+                {
+                    ErrorCodeText = e.ToString();
+                }
                 this.EstimatedInstallTime = WMIObject.Properties["EstimatedInstallTime"].Value as uint?;
                 this.EvaluationState = WMIObject.Properties["EvaluationState"].Value as uint?;
                 this.FullName = WMIObject.Properties["FullName"].Value as string;


### PR DESCRIPTION
Use a dll provided by the cm client, if present, to look up error codes and attach the localized error message to `CCM_SoftwareBase` and anything that inherits from it.

Currently always returns en-US messages, but in principle supports any language a cm translation exists for.