### PR TITLE
Prevent that a profile of the connecting user is created on the remot…

### DIFF
--- a/sccmclictr.automation/SCCMAgent.cs
+++ b/sccmclictr.automation/SCCMAgent.cs
@@ -336,6 +336,7 @@ namespace sccmclictr.automation
             connectionInfo.OpenTimeout = 60000;
             connectionInfo.CancelTimeout = 10000;
             connectionInfo.IdleTimeout = 60000;
+            connectionInfo.NoMachineProfile = true;
 
             if (bConnect)
                 connect();


### PR DESCRIPTION
…e computer.

Prevent that a profile of the connecting is created on the remote computer. I can see no reason when it is wanted to create a remote profile. If there is please add this as an option in the SCCMCliCtrWPF.exe.config file.